### PR TITLE
improvement: fix static builder method generation w/ non alphabetic properties

### DIFF
--- a/fern-java-codegen-utils/src/main/java/com/fern/codegen/GeneratedFileWithDefinition.java
+++ b/fern-java-codegen-utils/src/main/java/com/fern/codegen/GeneratedFileWithDefinition.java
@@ -1,6 +1,0 @@
-package com.fern.codegen;
-
-public interface GeneratedFileWithDefinition<D> extends IGeneratedFile {
-
-    D definition();
-}

--- a/fern-jersey-codegen/src/main/java/com/fern/services/jersey/codegen/GeneratedServiceWithDefinition.java
+++ b/fern-jersey-codegen/src/main/java/com/fern/services/jersey/codegen/GeneratedServiceWithDefinition.java
@@ -1,13 +1,15 @@
 package com.fern.services.jersey.codegen;
 
-import com.fern.codegen.GeneratedFileWithDefinition;
+import com.fern.codegen.GeneratedFile;
 import com.fern.immutables.StagedBuilderStyle;
 import com.services.http.HttpService;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @StagedBuilderStyle
-public interface GeneratedServiceWithDefinition extends GeneratedFileWithDefinition<HttpService> {
+public interface GeneratedServiceWithDefinition extends GeneratedFile {
+
+    HttpService httpService();
 
     static ImmutableGeneratedServiceWithDefinition.FileBuildStage builder() {
         return ImmutableGeneratedServiceWithDefinition.builder();

--- a/fern-jersey-codegen/src/main/java/com/fern/services/jersey/codegen/ServiceGenerator.java
+++ b/fern-jersey-codegen/src/main/java/com/fern/services/jersey/codegen/ServiceGenerator.java
@@ -75,7 +75,7 @@ public final class ServiceGenerator {
         return GeneratedServiceWithDefinition.builder()
                 .file(jerseyServiceJavaFile)
                 .className(generatedServiceClassName)
-                .definition(httpService)
+                .httpService(httpService)
                 .build();
     }
 

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/Generator.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/Generator.java
@@ -1,8 +1,8 @@
 package com.fern.model.codegen;
 
-import com.fern.codegen.GeneratedFileWithDefinition;
+import com.fern.codegen.GeneratedFile;
 
-public abstract class Generator<D> {
+public abstract class Generator {
 
     @SuppressWarnings("VisibilityModifier")
     protected final GeneratorContext generatorContext;
@@ -11,5 +11,5 @@ public abstract class Generator<D> {
         this.generatorContext = generatorContext;
     }
 
-    public abstract GeneratedFileWithDefinition<D> generate();
+    public abstract GeneratedFile generate();
 }

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/ModelGenerator.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/ModelGenerator.java
@@ -1,6 +1,6 @@
 package com.fern.model.codegen;
 
-import com.fern.codegen.GeneratedFileWithDefinition;
+import com.fern.codegen.GeneratedFile;
 import com.fern.codegen.IGeneratedFile;
 import com.fern.model.codegen.alias.AliasGenerator;
 import com.fern.model.codegen.config.PluginConfig;
@@ -61,7 +61,7 @@ public final class ModelGenerator {
 
     private List<JavaFile> generateJavaFiles() {
         Map<NamedType, GeneratedInterface> generatedInterfaces = getGeneratedInterfaces();
-        List<GeneratedFileWithDefinition<?>> generatedFiles = typeDefinitions.stream()
+        List<GeneratedFile> generatedFiles = typeDefinitions.stream()
                 .map(typeDefinition ->
                         typeDefinition.shape().accept(new TypeDefinitionGenerator(typeDefinition, generatedInterfaces)))
                 .collect(Collectors.toList());
@@ -95,7 +95,7 @@ public final class ModelGenerator {
         }));
     }
 
-    private final class TypeDefinitionGenerator implements Type.Visitor<GeneratedFileWithDefinition<?>> {
+    private final class TypeDefinitionGenerator implements Type.Visitor<GeneratedFile> {
 
         private final TypeDefinition typeDefinition;
         private final Map<NamedType, GeneratedInterface> generatedInterfaces;
@@ -106,7 +106,7 @@ public final class ModelGenerator {
         }
 
         @Override
-        public GeneratedFileWithDefinition<?> visitObject(ObjectTypeDefinition objectTypeDefinition) {
+        public GeneratedFile visitObject(ObjectTypeDefinition objectTypeDefinition) {
             Optional<GeneratedInterface> selfInterface =
                     Optional.ofNullable(generatedInterfaces.get(typeDefinition.name()));
             List<GeneratedInterface> extendedInterfaces = objectTypeDefinition._extends().stream()
@@ -120,28 +120,28 @@ public final class ModelGenerator {
         }
 
         @Override
-        public GeneratedFileWithDefinition<?> visitUnion(UnionTypeDefinition unionTypeDefinition) {
+        public GeneratedFile visitUnion(UnionTypeDefinition unionTypeDefinition) {
             UnionGenerator unionGenerator =
                     new UnionGenerator(typeDefinition.name(), unionTypeDefinition, generatorContext);
             return unionGenerator.generate();
         }
 
         @Override
-        public GeneratedFileWithDefinition<?> visitAlias(AliasTypeDefinition aliasTypeDefinition) {
+        public GeneratedFile visitAlias(AliasTypeDefinition aliasTypeDefinition) {
             AliasGenerator aliasGenerator =
                     new AliasGenerator(aliasTypeDefinition, typeDefinition.name(), generatorContext);
             return aliasGenerator.generate();
         }
 
         @Override
-        public GeneratedFileWithDefinition<?> visitEnum(EnumTypeDefinition enumTypeDefinition) {
+        public GeneratedFile visitEnum(EnumTypeDefinition enumTypeDefinition) {
             EnumGenerator enumGenerator =
                     new EnumGenerator(typeDefinition.name(), enumTypeDefinition, generatorContext);
             return enumGenerator.generate();
         }
 
         @Override
-        public GeneratedFileWithDefinition<?> visitUnknown(String unknownType) {
+        public GeneratedFile visitUnknown(String unknownType) {
             throw new RuntimeException("Encountered unknown Type: " + unknownType);
         }
     }

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/alias/AliasGenerator.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/alias/AliasGenerator.java
@@ -16,7 +16,7 @@ import java.util.List;
 import javax.lang.model.element.Modifier;
 import org.immutables.value.Value;
 
-public final class AliasGenerator extends Generator<AliasTypeDefinition> {
+public final class AliasGenerator extends Generator {
 
     private static final Modifier[] ALIAS_CLASS_MODIFIERS = new Modifier[] {Modifier.PUBLIC};
 
@@ -61,7 +61,7 @@ public final class AliasGenerator extends Generator<AliasTypeDefinition> {
         return GeneratedAlias.builder()
                 .file(aliasFile)
                 .className(generatedAliasClassName)
-                .definition(aliasTypeDefinition)
+                .aliasTypeDefinition(aliasTypeDefinition)
                 .build();
     }
 

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/alias/GeneratedAlias.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/alias/GeneratedAlias.java
@@ -1,13 +1,15 @@
 package com.fern.model.codegen.alias;
 
-import com.fern.codegen.GeneratedFileWithDefinition;
+import com.fern.codegen.GeneratedFile;
 import com.fern.immutables.StagedBuilderStyle;
 import com.types.AliasTypeDefinition;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @StagedBuilderStyle
-public interface GeneratedAlias extends GeneratedFileWithDefinition<AliasTypeDefinition> {
+public interface GeneratedAlias extends GeneratedFile {
+
+    AliasTypeDefinition aliasTypeDefinition();
 
     static ImmutableGeneratedAlias.FileBuildStage builder() {
         return ImmutableGeneratedAlias.builder();

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/enums/EnumGenerator.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/enums/EnumGenerator.java
@@ -28,7 +28,7 @@ import javax.annotation.Nonnull;
 import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 
-public final class EnumGenerator extends Generator<EnumTypeDefinition> {
+public final class EnumGenerator extends Generator {
 
     private static final Modifier[] ENUM_CLASS_MODIFIERS = new Modifier[] {Modifier.PUBLIC, Modifier.FINAL};
 
@@ -90,7 +90,7 @@ public final class EnumGenerator extends Generator<EnumTypeDefinition> {
         return GeneratedEnum.builder()
                 .file(enumFile)
                 .className(generatedEnumClassName)
-                .definition(enumTypeDefinition)
+                .enumTypeDefinition(enumTypeDefinition)
                 .build();
     }
 

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/enums/GeneratedEnum.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/enums/GeneratedEnum.java
@@ -1,13 +1,15 @@
 package com.fern.model.codegen.enums;
 
-import com.fern.codegen.GeneratedFileWithDefinition;
+import com.fern.codegen.GeneratedFile;
 import com.fern.immutables.StagedBuilderStyle;
 import com.types.EnumTypeDefinition;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @StagedBuilderStyle
-public interface GeneratedEnum extends GeneratedFileWithDefinition<EnumTypeDefinition> {
+public interface GeneratedEnum extends GeneratedFile {
+
+    EnumTypeDefinition enumTypeDefinition();
 
     static ImmutableGeneratedEnum.FileBuildStage builder() {
         return ImmutableGeneratedEnum.builder();

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/interfaces/GeneratedInterface.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/interfaces/GeneratedInterface.java
@@ -1,13 +1,15 @@
 package com.fern.model.codegen.interfaces;
 
-import com.fern.codegen.GeneratedFileWithDefinition;
+import com.fern.codegen.GeneratedFile;
 import com.fern.immutables.StagedBuilderStyle;
 import com.types.ObjectTypeDefinition;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @StagedBuilderStyle
-public interface GeneratedInterface extends GeneratedFileWithDefinition<ObjectTypeDefinition> {
+public interface GeneratedInterface extends GeneratedFile {
+
+    ObjectTypeDefinition objectTypeDefinition();
 
     static ImmutableGeneratedInterface.FileBuildStage builder() {
         return ImmutableGeneratedInterface.builder();

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/interfaces/GeneratedInterface.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/interfaces/GeneratedInterface.java
@@ -2,7 +2,10 @@ package com.fern.model.codegen.interfaces;
 
 import com.fern.codegen.GeneratedFile;
 import com.fern.immutables.StagedBuilderStyle;
+import com.squareup.javapoet.MethodSpec;
+import com.types.ObjectProperty;
 import com.types.ObjectTypeDefinition;
+import java.util.Map;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -10,6 +13,8 @@ import org.immutables.value.Value;
 public interface GeneratedInterface extends GeneratedFile {
 
     ObjectTypeDefinition objectTypeDefinition();
+
+    Map<ObjectProperty, MethodSpec> methodSpecsByProperties();
 
     static ImmutableGeneratedInterface.FileBuildStage builder() {
         return ImmutableGeneratedInterface.builder();

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/interfaces/InterfaceGenerator.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/interfaces/InterfaceGenerator.java
@@ -9,7 +9,7 @@ import com.types.NamedType;
 import com.types.ObjectTypeDefinition;
 import javax.lang.model.element.Modifier;
 
-public final class InterfaceGenerator extends Generator<ObjectTypeDefinition> {
+public final class InterfaceGenerator extends Generator {
 
     private static final String INTERFACE_PREFIX = "I";
     private static final String INTERFACES_PACKAGE_NAME = "interfaces";
@@ -39,7 +39,7 @@ public final class InterfaceGenerator extends Generator<ObjectTypeDefinition> {
         return GeneratedInterface.builder()
                 .file(interfaceFile)
                 .className(generatedInterfaceClassName)
-                .definition(objectTypeDefinition)
+                .objectTypeDefinition(objectTypeDefinition)
                 .build();
     }
 

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/interfaces/InterfaceGenerator.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/interfaces/InterfaceGenerator.java
@@ -4,9 +4,12 @@ import com.fern.model.codegen.Generator;
 import com.fern.model.codegen.GeneratorContext;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeSpec;
 import com.types.NamedType;
+import com.types.ObjectProperty;
 import com.types.ObjectTypeDefinition;
+import java.util.Map;
 import javax.lang.model.element.Modifier;
 
 public final class InterfaceGenerator extends Generator {
@@ -27,12 +30,11 @@ public final class InterfaceGenerator extends Generator {
     @Override
     public GeneratedInterface generate() {
         ClassName generatedInterfaceClassName = getInterfaceClassName();
+        Map<ObjectProperty, MethodSpec> methodSpecsByProperties =
+                generatorContext.getImmutablesUtils().getImmutablesPropertyMethods(objectTypeDefinition);
         TypeSpec interfaceTypeSpec = TypeSpec.interfaceBuilder(generatedInterfaceClassName.simpleName())
                 .addModifiers(Modifier.PUBLIC)
-                .addMethods(generatorContext
-                        .getImmutablesUtils()
-                        .getImmutablesPropertyMethods(objectTypeDefinition)
-                        .values())
+                .addMethods(methodSpecsByProperties.values())
                 .build();
         JavaFile interfaceFile = JavaFile.builder(generatedInterfaceClassName.packageName(), interfaceTypeSpec)
                 .build();
@@ -40,6 +42,7 @@ public final class InterfaceGenerator extends Generator {
                 .file(interfaceFile)
                 .className(generatedInterfaceClassName)
                 .objectTypeDefinition(objectTypeDefinition)
+                .putAllMethodSpecsByProperties(methodSpecsByProperties)
                 .build();
     }
 

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/object/GeneratedObject.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/object/GeneratedObject.java
@@ -1,13 +1,15 @@
 package com.fern.model.codegen.object;
 
-import com.fern.codegen.GeneratedFileWithDefinition;
+import com.fern.codegen.GeneratedFile;
 import com.fern.immutables.StagedBuilderStyle;
 import com.types.ObjectTypeDefinition;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @StagedBuilderStyle
-public interface GeneratedObject extends GeneratedFileWithDefinition<ObjectTypeDefinition> {
+public interface GeneratedObject extends GeneratedFile {
+
+    ObjectTypeDefinition objectTypeDefinition();
 
     static ImmutableGeneratedObject.FileBuildStage builder() {
         return ImmutableGeneratedObject.builder();

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/object/ObjectGenerator.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/object/ObjectGenerator.java
@@ -2,7 +2,7 @@ package com.fern.model.codegen.object;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fern.codegen.GeneratedFileWithDefinition;
+import com.fern.codegen.GeneratedFile;
 import com.fern.model.codegen.Generator;
 import com.fern.model.codegen.GeneratorContext;
 import com.fern.model.codegen.interfaces.GeneratedInterface;
@@ -25,7 +25,7 @@ import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 import org.immutables.value.Value;
 
-public final class ObjectGenerator extends Generator<ObjectTypeDefinition> {
+public final class ObjectGenerator extends Generator {
 
     private static final Modifier[] OBJECT_INTERFACE_MODIFIERS = new Modifier[] {Modifier.PUBLIC};
 
@@ -73,7 +73,7 @@ public final class ObjectGenerator extends Generator<ObjectTypeDefinition> {
         return GeneratedObject.builder()
                 .file(objectFile)
                 .className(generatedObjectClassName)
-                .definition(objectTypeDefinition)
+                .objectTypeDefinition(objectTypeDefinition)
                 .build();
     }
 
@@ -94,7 +94,7 @@ public final class ObjectGenerator extends Generator<ObjectTypeDefinition> {
     private List<TypeName> getSuperInterfaces() {
         List<TypeName> superInterfaces = new ArrayList<>();
         superInterfaces.addAll(extendedInterfaces.stream()
-                .map(GeneratedFileWithDefinition::className)
+                .map(GeneratedFile::className)
                 .collect(Collectors.toList()));
         selfInterface.ifPresent(generatedInterface -> superInterfaces.add(generatedInterface.className()));
         return superInterfaces;
@@ -119,7 +119,7 @@ public final class ObjectGenerator extends Generator<ObjectTypeDefinition> {
         // Required field from super interfaces take priority
         for (GeneratedInterface superInterface : superInterfaces) {
             Optional<String> firstMandatoryFieldName =
-                    getFirstRequiredFieldName(superInterface.definition().properties());
+                    getFirstRequiredFieldName(superInterface.objectTypeDefinition().properties());
             if (firstMandatoryFieldName.isPresent()) {
                 return firstMandatoryFieldName;
             }

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/union/GeneratedUnion.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/union/GeneratedUnion.java
@@ -1,13 +1,15 @@
 package com.fern.model.codegen.union;
 
-import com.fern.codegen.GeneratedFileWithDefinition;
+import com.fern.codegen.GeneratedFile;
 import com.fern.immutables.StagedBuilderStyle;
 import com.types.UnionTypeDefinition;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @StagedBuilderStyle
-public interface GeneratedUnion extends GeneratedFileWithDefinition<UnionTypeDefinition> {
+public interface GeneratedUnion extends GeneratedFile {
+
+    UnionTypeDefinition unionTypeDefinition();
 
     static ImmutableGeneratedUnion.FileBuildStage builder() {
         return ImmutableGeneratedUnion.builder();

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/union/UnionGenerator.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/union/UnionGenerator.java
@@ -39,7 +39,7 @@ import javax.lang.model.element.Modifier;
 import org.apache.commons.lang3.StringUtils;
 import org.immutables.value.Value;
 
-public final class UnionGenerator extends Generator<UnionTypeDefinition> {
+public final class UnionGenerator extends Generator {
 
     private static final Modifier[] UNION_CLASS_MODIFIERS = new Modifier[] {Modifier.PUBLIC, Modifier.FINAL};
 
@@ -106,7 +106,7 @@ public final class UnionGenerator extends Generator<UnionTypeDefinition> {
         return GeneratedUnion.builder()
                 .file(unionFile)
                 .className(generatedUnionClassName)
-                .definition(unionTypeDefinition)
+                .unionTypeDefinition(unionTypeDefinition)
                 .build();
     }
 

--- a/fern-model-codegen/src/test/java/com/fern/model/codegen/object/ObjectGeneratorTest.java
+++ b/fern-model-codegen/src/test/java/com/fern/model/codegen/object/ObjectGeneratorTest.java
@@ -94,4 +94,34 @@ public class ObjectGeneratorTest {
         GeneratedObject object = objectGenerator.generate();
         System.out.println(object.file().toString());
     }
+
+    @Test
+    public void test_underscoredProperty() {
+        ObjectTypeDefinition objectTypeDefinition = ObjectTypeDefinition.builder()
+                .addProperties(ObjectProperty.builder()
+                        .key("_class")
+                        .valueType(TypeReference.container(
+                                ContainerType.optional(TypeReference.primitive(PrimitiveType.STRING))))
+                        .build())
+                .addProperties(ObjectProperty.builder()
+                        .key("_returns")
+                        .valueType(TypeReference.primitive(PrimitiveType.STRING))
+                        .build())
+                .build();
+        TypeDefinition typeDefinition = TypeDefinition.builder()
+                .name(NamedType.builder()
+                        .fernFilepath(FernFilepath.valueOf("com/fern"))
+                        .name("Test")
+                        .build())
+                .shape(Type._object(objectTypeDefinition))
+                .build();
+        ObjectGenerator objectGenerator = new ObjectGenerator(
+                typeDefinition.name(),
+                objectTypeDefinition,
+                Collections.emptyList(),
+                Optional.empty(),
+                TestConstants.GENERATOR_CONTEXT);
+        GeneratedObject object = objectGenerator.generate();
+        System.out.println(object.file().toString());
+    }
 }


### PR DESCRIPTION
**Expected:** an immutables property like `String _class()` should have a static staged builder method with the signature: 

```java
static Immutable<Class>._classBuildStage builder() {
  return Immutable<Class>.builder();
}
```

Instead we would generate 
```java
static Immutable<Class>.ClassBuildStage builder() {
  return Immutable<Class>.builder();
}
```
which would fail to compile.