### PR TITLE
fix: visitor references shouldn't assume camel cased discriminants

### DIFF
--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/enums/EnumGenerator.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/enums/EnumGenerator.java
@@ -193,7 +193,7 @@ public final class EnumGenerator extends Generator {
      *     }
      * }
      */
-    private MethodSpec getAcceptMethod(GeneratedVisitor generatedVisitor) {
+    private MethodSpec getAcceptMethod(GeneratedVisitor<EnumValue> generatedVisitor) {
         CodeBlock.Builder acceptMethodImplementation = CodeBlock.builder().beginControlFlow("switch (value)");
         generatedVisitor.visitMethodsByKeyName().forEach((keyName, visitMethod) -> {
             acceptMethodImplementation
@@ -295,10 +295,10 @@ public final class EnumGenerator extends Generator {
      *     T visitUnknownType(String unknownType);
      * }
      */
-    private GeneratedVisitor getVisitor() {
-        List<VisitorUtils.VisitMethodArgs> visitMethodArgs = enumTypeDefinition.values().stream()
-                .map(enumValue -> VisitorUtils.VisitMethodArgs.builder()
-                        // TODO(dsinghvi): Should we handle underscores in enum values by removing them and camelCasing?
+    private GeneratedVisitor<EnumValue> getVisitor() {
+        List<VisitorUtils.VisitMethodArgs<EnumValue>> visitMethodArgs = enumTypeDefinition.values().stream()
+                .map(enumValue -> VisitorUtils.VisitMethodArgs.<EnumValue>builder()
+                        .key(enumValue)
                         .keyName(enumValue.value())
                         .build())
                 .collect(Collectors.toList());

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/utils/VisitorUtils.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/utils/VisitorUtils.java
@@ -70,7 +70,7 @@ public final class VisitorUtils {
 
         default MethodSpec convertToMethod() {
             MethodSpec.Builder methodSpecBuilder = MethodSpec.methodBuilder(VISITOR_VISIT_METHOD_NAME_PREFIX
-                            + StringUtils.capitalize(keyName().toLowerCase()))
+                            + StringUtils.capitalize(keyName()))
                     .addModifiers(Modifier.ABSTRACT, Modifier.PUBLIC)
                     .returns(VISITOR_RETURN_TYPE);
             if (visitorType().isPresent()) {

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/utils/VisitorUtils.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/utils/VisitorUtils.java
@@ -69,8 +69,8 @@ public final class VisitorUtils {
         Optional<TypeName> visitorType();
 
         default MethodSpec convertToMethod() {
-            MethodSpec.Builder methodSpecBuilder = MethodSpec.methodBuilder(VISITOR_VISIT_METHOD_NAME_PREFIX
-                            + StringUtils.capitalize(keyName()))
+            MethodSpec.Builder methodSpecBuilder = MethodSpec.methodBuilder(
+                            VISITOR_VISIT_METHOD_NAME_PREFIX + StringUtils.capitalize(keyName()))
                     .addModifiers(Modifier.ABSTRACT, Modifier.PUBLIC)
                     .returns(VISITOR_RETURN_TYPE);
             if (visitorType().isPresent()) {

--- a/fern-model-codegen/src/main/java/com/fern/model/codegen/utils/VisitorUtils.java
+++ b/fern-model-codegen/src/main/java/com/fern/model/codegen/utils/VisitorUtils.java
@@ -34,12 +34,12 @@ public final class VisitorUtils {
         return ParameterizedTypeName.get(visitorInterfaceClassName, VISITOR_RETURN_TYPE);
     }
 
-    public GeneratedVisitor buildVisitorInterface(List<VisitMethodArgs> visitMethodArgsList) {
-        Map<String, MethodSpec> visitMethodsByKeyName = new HashMap<>();
+    public <T> GeneratedVisitor<T> buildVisitorInterface(List<VisitMethodArgs<T>> visitMethodArgsList) {
+        Map<T, MethodSpec> visitMethodsByKeyName = new HashMap<>();
         List<MethodSpec> visitMethods = visitMethodArgsList.stream()
                 .map(visitMethodArgs -> {
                     MethodSpec visitMethod = visitMethodArgs.convertToMethod();
-                    visitMethodsByKeyName.put(visitMethodArgs.keyName(), visitMethod);
+                    visitMethodsByKeyName.put(visitMethodArgs.key(), visitMethod);
                     return visitMethod;
                 })
                 .collect(Collectors.toList());
@@ -53,7 +53,7 @@ public final class VisitorUtils {
                         .returns(VISITOR_RETURN_TYPE)
                         .build())
                 .build();
-        return GeneratedVisitor.builder()
+        return GeneratedVisitor.<T>builder()
                 .typeSpec(visitorTypeSpec)
                 .putAllVisitMethodsByKeyName(visitMethodsByKeyName)
                 .build();
@@ -61,7 +61,9 @@ public final class VisitorUtils {
 
     @Value.Immutable
     @StagedBuilderStyle
-    public interface VisitMethodArgs {
+    public interface VisitMethodArgs<T> {
+        T key();
+
         String keyName();
 
         Optional<TypeName> visitorType();
@@ -77,19 +79,19 @@ public final class VisitorUtils {
             return methodSpecBuilder.build();
         }
 
-        static ImmutableVisitMethodArgs.KeyNameBuildStage builder() {
+        static <T> ImmutableVisitMethodArgs.KeyBuildStage<T> builder() {
             return ImmutableVisitMethodArgs.builder();
         }
     }
 
     @Value.Immutable
     @StagedBuilderStyle
-    public interface GeneratedVisitor {
+    public interface GeneratedVisitor<T> {
         TypeSpec typeSpec();
 
-        Map<String, MethodSpec> visitMethodsByKeyName();
+        Map<T, MethodSpec> visitMethodsByKeyName();
 
-        static ImmutableGeneratedVisitor.TypeSpecBuildStage builder() {
+        static <T> ImmutableGeneratedVisitor.TypeSpecBuildStage<T> builder() {
             return ImmutableGeneratedVisitor.builder();
         }
     }

--- a/fern-model-codegen/src/test/java/com/fern/model/codegen/union/UnionGeneratorTest.java
+++ b/fern-model-codegen/src/test/java/com/fern/model/codegen/union/UnionGeneratorTest.java
@@ -64,4 +64,38 @@ public class UnionGeneratorTest {
         GeneratedUnion generatedUnion = unionGenerator.generate();
         System.out.println(generatedUnion.file().toString());
     }
+
+    @Test
+    public void test_nonCamelCaseDiscriminants() {
+        UnionTypeDefinition unionTypeDefinition = UnionTypeDefinition.builder()
+                .discriminant("_type")
+                .addTypes(SingleUnionType.builder()
+                        .discriminantValue("integervalue")
+                        .valueType(TypeReference.primitive(PrimitiveType.INTEGER))
+                        .build())
+                .addTypes(SingleUnionType.builder()
+                        .discriminantValue("booleanvalue")
+                        .valueType(TypeReference.primitive(PrimitiveType.BOOLEAN))
+                        .build())
+                .addTypes(SingleUnionType.builder()
+                        .discriminantValue("doublevalue")
+                        .valueType(TypeReference.primitive(PrimitiveType.DOUBLE))
+                        .build())
+                .build();
+        TypeDefinition variableValueTypeDefinition = TypeDefinition.builder()
+                .name(NamedType.builder()
+                        .fernFilepath(FernFilepath.valueOf("com/birch/trace/commons"))
+                        .name("VariableValue")
+                        .build())
+                .shape(Type.union(unionTypeDefinition))
+                .build();
+        GeneratorContext generatorContext = new GeneratorContext(TestConstants.PLUGIN_CONFIG,
+                Collections.singletonMap(variableValueTypeDefinition.name(), variableValueTypeDefinition));
+        UnionGenerator unionGenerator = new UnionGenerator(
+                variableValueTypeDefinition.name(),
+                unionTypeDefinition,
+                generatorContext);
+        GeneratedUnion generatedUnion = unionGenerator.generate();
+        System.out.println(generatedUnion.file().toString());
+    }
 }


### PR DESCRIPTION
When we use a method name we should use the MethodSpec and get the name. For visit method names, we were relying on capitalization which is error prone.